### PR TITLE
Fix #2 resizing the game in battle no longer crashes it.

### DIFF
--- a/core/src/com/mygdx/game/Map/BattleMap.java
+++ b/core/src/com/mygdx/game/Map/BattleMap.java
@@ -94,8 +94,11 @@ public class BattleMap extends Map{
             if( object.getName().equalsIgnoreCase(PLAYER_START) ){
             	((RectangleMapObject)object).getRectangle().getPosition(_playerStartPositionRect);
             	TiledMapActor actor = (TiledMapActor) tiledmapstage.hit(TiledMapPosition.getUpScaledX(_playerStartPositionRect.x), TiledMapPosition.getUpScaledY(_playerStartPositionRect.y), false);
-            	actor.debug();
-    	        actor.drawDebug(debugRenderer);
+            	// While resizing the screen, the actor wont be available until letting go of the resize.
+            	if ( actor != null ) {
+            	    actor.debug();
+                    actor.drawDebug(debugRenderer);
+                }
             }
         }
 		debugRenderer.end();


### PR DESCRIPTION
Hi,

this was the cause for the resize crashing into a null pointer. During a resize the actor object is not available as the position rectangles are being moved around by the user along with the resize.

I hope its ok I wrote a comment in there describing this a little.