### PR TITLE
Fix #9 Action menu blocks movement

### DIFF
--- a/core/src/com/mygdx/game/Entities/Entity.java
+++ b/core/src/com/mygdx/game/Entities/Entity.java
@@ -178,6 +178,7 @@ public class Entity extends Actor implements EntitySubject{
 	public void setInMovementPhase(boolean isInMovementPhase) {
 		this.isInMovementPhase = isInMovementPhase;
 		if(isInMovementPhase) {
+			actionsui.setVisible(false);			
 			this.notify(EntityCommand.IN_MOVEMENT);
 		}
 	}


### PR DESCRIPTION
Hides Acction Menu while moving (Fix #9 ). 

TODO:
- Insert 'Back button' to dismiss movement and view Action Menu again. (Not implemented because is a Desingners decision the abbility to cancel the movement)